### PR TITLE
Flush pending responses after exiting multi

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -41,6 +41,8 @@ module Dalli
       :rcvbuf => nil
     }
 
+    ALLOWED_MULTI_OPS = %i[set setq delete deleteq add addq replace replaceq].freeze
+
     def initialize(attribs, options = {})
       @hostname, @port, @weight, @socket_type = parse_hostname(attribs)
       @fail_count = 0
@@ -52,6 +54,7 @@ module Dalli
       @error = nil
       @pid = nil
       @inprogress = nil
+      @pending_multi_response = nil
     end
 
     def name
@@ -67,6 +70,11 @@ module Dalli
       verify_state
       raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
       begin
+        # if we have exited a multi block, flush any responses that might still be pending
+        if @pending_multi_response && (!multi? || !ALLOWED_MULTI_OPS.include?(op))
+          noop
+          @pending_multi_response = false
+        end
         send(op, *args)
       rescue Dalli::MarshalError => ex
         Dalli.logger.error "Marshalling error for key '#{args.first}': #{ex.message}"
@@ -288,6 +296,7 @@ module Dalli
       guard_max_value(key, value) do
         req = [REQUEST, OPCODES[multi? ? :setq : :set], key.bytesize, 8, 0, 0, value.bytesize + key.bytesize + 8, 0, cas, flags, ttl, key, value].pack(FORMAT[:set])
         write(req)
+        @pending_multi_response ||= multi?
         cas_response unless multi?
       end
     end
@@ -299,6 +308,7 @@ module Dalli
       guard_max_value(key, value) do
         req = [REQUEST, OPCODES[multi? ? :addq : :add], key.bytesize, 8, 0, 0, value.bytesize + key.bytesize + 8, 0, 0, flags, ttl, key, value].pack(FORMAT[:add])
         write(req)
+        @pending_multi_response ||= multi?
         cas_response unless multi?
       end
     end
@@ -310,6 +320,7 @@ module Dalli
       guard_max_value(key, value) do
         req = [REQUEST, OPCODES[multi? ? :replaceq : :replace], key.bytesize, 8, 0, 0, value.bytesize + key.bytesize + 8, 0, cas, flags, ttl, key, value].pack(FORMAT[:replace])
         write(req)
+        @pending_multi_response ||= multi?
         cas_response unless multi?
       end
     end
@@ -317,6 +328,7 @@ module Dalli
     def delete(key, cas)
       req = [REQUEST, OPCODES[multi? ? :deleteq : :delete], key.bytesize, 0, 0, 0, key.bytesize, 0, cas, key].pack(FORMAT[:delete])
       write(req)
+      @pending_multi_response ||= multi?
       generic_response unless multi?
     end
 

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -375,7 +375,7 @@ module Dalli
     # We need to read all the responses at once.
     def noop
       write_noop
-      multi_response
+      flush_response
     end
 
     def append(key, value)
@@ -556,15 +556,11 @@ module Dalli
       end
     end
 
-    def multi_response
-      hash = {}
+    def flush_response
       while true
-        (key_length, _, body_length, _) = read_header.unpack(KV_HEADER)
-        return hash if key_length == 0
-        flags = read(4).unpack('N')[0]
-        key = read(key_length)
-        value = read(body_length - key_length - 4) if body_length - key_length - 4 > 0
-        hash[key] = deserialize(value, flags)
+        (key_length, status, body_length, _) = read_header.unpack(KV_HEADER)
+        return if key_length == 0 && status == 0
+        read(body_length)
       end
     end
 

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -560,7 +560,7 @@ module Dalli
       while true
         (key_length, status, body_length, _) = read_header.unpack(KV_HEADER)
         return if key_length == 0 && status == 0
-        read(body_length)
+        read(body_length) if body_length > 0
       end
     end
 

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -334,6 +334,23 @@ describe 'Dalli' do
       end
     end
 
+    it 'does not corrupt multiget with errors' do
+      memcached_persistent do |dc|
+        dc.close
+        dc.flush
+        dc.set('a', 'av')
+        dc.set('b', 'bv')
+        assert_equal 'av', dc.get('a')
+        assert_equal 'bv', dc.get('b')
+
+        dc.multi do
+          dc.delete('non_existent_key')
+        end
+        assert_equal 'av', dc.get('a')
+        assert_equal 'bv', dc.get('b')
+      end
+    end
+
     it 'support raw incr/decr' do
       memcached_persistent do |client|
         client.flush


### PR DESCRIPTION
Each server uses a boolean to record whether quiet-mode commands executed inside a `multi` block may have pending responses. These responses are flushed before the next non-multi command by executing a `noop` command.

The `noop` command was broken - it was assuming that all responses are key/value pairs, as would be the case after a `get_multi`.

However, `noop` can be done at any time. In particular, it can be done to conclude a `multi` block.

Correctly drain the responses by checking the key length and status, and reading but discarding any response bodies.

This mirrors how the latest version of Dalli works:
https://github.com/petergoldstein/dalli/blob/main/lib/dalli/protocol/binary/response_processor.rb#L150