### PR TITLE
Don't require the railtie

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -6,7 +6,6 @@ require 'dalli/server'
 require 'dalli/socket'
 require 'dalli/version'
 require 'dalli/options'
-require 'dalli/railtie' if defined?(::Rails::Railtie)
 
 module Dalli
   # generic error


### PR DESCRIPTION
I removed it, but missed the `require`