### PR TITLE
Only lock servers involved in get_multi

### DIFF
--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -46,12 +46,13 @@ module Dalli
       raise Dalli::RingError, "No server available"
     end
 
-    def lock
-      @servers.each(&:lock!)
+    def lock(servers)
+      locked_servers = servers.dup # make a copy, since the argument may be mutated after locking
+      locked_servers.each(&:lock!)
       begin
         return yield
       ensure
-        @servers.each(&:unlock!)
+        locked_servers.each(&:unlock!)
       end
     end
 


### PR DESCRIPTION
Instead of locking the entire ring, we can lock only those servers that have some of the requested keys.

I don't think this will have much of an impact, but it nevertheless makes sense to reduce contention between non-overlapping requests.