### PR TITLE
[PLATI-1363] Use Identity as the default compressor & serializer

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'dalli/compressor'
+require 'dalli/identity'
 require 'dalli/client'
 require 'dalli/ring'
 require 'dalli/server'

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -26,8 +26,8 @@ module Dalli
     # - :threadsafe - ensure that only one thread is actively using a socket at a time. Default: true.
     # - :expires_in - default TTL in seconds if you do not pass TTL as a parameter to an individual operation, defaults to 0 or forever
     # - :compress - defaults to false, if true Dalli will compress values larger than 1024 bytes before sending them to memcached.
-    # - :serializer - defaults to Marshal
-    # - :compressor - defaults to zlib
+    # - :serializer - defaults to Identity
+    # - :compressor - defaults to Identity
     # - :cache_nils - defaults to false, if true Dalli will not treat cached nil values as 'not found' for #fetch operations.
     # - :digest_class - defaults to Digest::MD5, allows you to pass in an object that responds to the hexdigest method, useful for injecting a FIPS compliant hash object.
     #

--- a/lib/dalli/identity.rb
+++ b/lib/dalli/identity.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Dalli
+  class Identity
+    # A no-op serializer/compressor that always returns its input
+
+    class << self
+      def dump(value)
+        return value
+      end
+
+      def load(value)
+        return value
+      end
+
+      def compress(value)
+        return value
+      end
+
+      def decompress(value)
+        return value
+      end
+    end
+  end
+end

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -26,12 +26,12 @@ module Dalli
       :value_max_bytes => 1024 * 1024,
       # surpassing value_max_bytes either warns (false) or throws (true)
       :error_when_over_max_size => false,
-      :compressor => (defined?($TESTING) && $TESTING) ? Compressor : Dalli::Identity,
+      :compressor => (defined?($TESTING) && $TESTING) ? Compressor : Identity,
       # min byte size to attempt compression
       :compression_min_size => 1024,
       # max byte size for compression
       :compression_max_size => false,
-      :serializer => (defined?($TESTING) && $TESTING) ? Marshal : Dalli::Identity,
+      :serializer => (defined?($TESTING) && $TESTING) ? Marshal : Identity,
       :username => nil,
       :password => nil,
       :keepalive => true,

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -26,12 +26,12 @@ module Dalli
       :value_max_bytes => 1024 * 1024,
       # surpassing value_max_bytes either warns (false) or throws (true)
       :error_when_over_max_size => false,
-      :compressor => Compressor,
+      :compressor => (defined?($TESTING) && $TESTING) ? Compressor : Dalli::Identity,
       # min byte size to attempt compression
       :compression_min_size => 1024,
       # max byte size for compression
       :compression_max_size => false,
-      :serializer => Marshal,
+      :serializer => (defined?($TESTING) && $TESTING) ? Marshal : Dalli::Identity,
       :username => nil,
       :password => nil,
       :keepalive => true,

--- a/test/test_identity.rb
+++ b/test/test_identity.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+describe 'Identity' do
+  subject { Dalli::Identity }
+
+  let(:some_value) { SecureRandom.alphanumeric(10) }
+  
+  it "implements the serializer interface (dump/load) with the identity function" do
+    assert_equal(some_value, subject.dump(some_value))
+    assert_equal(some_value, subject.load(some_value))
+  end
+
+  it "implements the compressor interface (compress/decompress) with the identity function" do
+    assert_equal(some_value, subject.compress(some_value))
+    assert_equal(some_value, subject.decompress(some_value))
+  end
+
+  it "works as a compressor & serializer" do
+    memcached(29199) do |_, port|
+      dc = Dalli::Client.new("localhost:#{port}", :compressor => subject, :serializer => subject)
+      dc.set('some_key', 'some_value')
+      assert_equal('some_value', dc.get('some_key')) 
+    end
+  end
+end


### PR DESCRIPTION
Changes in Rails 7.1 prevent us from passing these in from `platform` so this change adds the `Identity` serializer/compressor and makes it the default.