### PR TITLE
Backport changes from upstream v3

### DIFF
--- a/lib/dalli/pid_cache.rb
+++ b/lib/dalli/pid_cache.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dalli
+  ##
+  # Dalli::PIDCache is a wrapper class for PID checking to avoid system calls when checking the PID.
+  ##
+  module PIDCache
+    if !Process.respond_to?(:fork) # JRuby or TruffleRuby
+      @pid = Process.pid
+      singleton_class.attr_reader(:pid)
+    elsif Process.respond_to?(:_fork) # Ruby 3.1+
+      class << self
+        attr_reader :pid
+
+        def update!
+          @pid = Process.pid
+        end
+      end
+      update!
+
+      ##
+      # Dalli::PIDCache::CoreExt hooks into Process to be able to reset the PID cache after fork
+      ##
+      module CoreExt
+        def _fork
+          child_pid = super
+          PIDCache.update! if child_pid.zero?
+          child_pid
+        end
+      end
+      Process.singleton_class.prepend(CoreExt)
+    else # Ruby 3.0 or older
+      class << self
+        def pid
+          Process.pid
+        end
+      end
+    end
+  end
+end

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -32,7 +32,14 @@ module Dalli
       if @continuum
         hkey = hash_for(key)
         20.times do |try|
-          entryidx = binary_search(@continuum, hkey)
+          # Find the closest index in the Ring with value <= the given value
+          entryidx = @continuum.bsearch_index { |entry| entry.value > hkey }
+          if entryidx.nil?
+            entryidx = @continuum.size - 1
+          else
+            entryidx -= 1
+          end
+
           server = @continuum[entryidx].server
           return server if server.alive?
           break unless @failover
@@ -70,63 +77,6 @@ module Dalli
 
     def entry_count_for(server, total_servers, total_weight)
       ((total_servers * POINTS_PER_SERVER * server.weight) / Float(total_weight)).floor
-    end
-
-    # Native extension to perform the binary search within the continuum
-    # space.  Fallback to a pure Ruby version if the compilation doesn't work.
-    # optional for performance and only necessary if you are using multiple
-    # memcached servers.
-    begin
-      require 'inline'
-      inline do |builder|
-        builder.c <<-EOM
-        int binary_search(VALUE ary, unsigned int r) {
-            long upper = RARRAY_LEN(ary) - 1;
-            long lower = 0;
-            long idx = 0;
-            ID value = rb_intern("value");
-            VALUE continuumValue;
-            unsigned int l;
-
-            while (lower <= upper) {
-                idx = (lower + upper) / 2;
-
-                continuumValue = rb_funcall(RARRAY_PTR(ary)[idx], value, 0);
-                l = NUM2UINT(continuumValue);
-                if (l == r) {
-                    return idx;
-                }
-                else if (l > r) {
-                    upper = idx - 1;
-                }
-                else {
-                    lower = idx + 1;
-                }
-            }
-            return upper;
-        }
-        EOM
-      end
-    rescue LoadError
-      # Find the closest index in the Ring with value <= the given value
-      def binary_search(ary, value)
-        upper = ary.size - 1
-        lower = 0
-
-        while (lower <= upper) do
-          idx = (lower + upper) / 2
-          comp = ary[idx].value <=> value
-
-          if comp == 0
-            return idx
-          elsif comp > 0
-            upper = idx - 1
-          else
-            lower = idx + 1
-          end
-        end
-        upper
-      end
     end
 
     class Entry

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -2,6 +2,8 @@
 require 'socket'
 require 'timeout'
 
+require 'dalli/pid_cache'
+
 module Dalli
   class Server
     attr_accessor :hostname
@@ -214,7 +216,7 @@ module Dalli
 
     def verify_state
       failure!(RuntimeError.new('Already writing to socket')) if @inprogress
-      if @pid && @pid != Process.pid
+      if @pid && @pid != PIDCache.pid
         message = 'Fork detected, re-connecting child process...'
         Dalli.logger.info { message }
         reconnect! message
@@ -594,7 +596,7 @@ module Dalli
       Dalli.logger.debug { "Dalli::Server#connect #{name}" }
 
       begin
-        @pid = Process.pid
+        @pid = PIDCache.pid
         if socket_type == :unix
           @sock = KSocket::UNIX.open(hostname, self, options)
         else

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -45,6 +45,15 @@ module Dalli
 
     ALLOWED_MULTI_OPS = %i[set setq delete deleteq add addq replace replaceq].freeze
 
+    # Ruby 3.2 raises IO::TimeoutError on blocking reads/writes, but
+    # it is not defined in earlier Ruby versions.
+    TIMEOUT_ERRORS =
+      if defined?(IO::TimeoutError)
+        [Timeout::Error, IO::TimeoutError]
+      else
+        [Timeout::Error]
+      end
+
     def initialize(attribs, options = {})
       @hostname, @port, @weight, @socket_type = parse_hostname(attribs)
       @fail_count = 0
@@ -83,7 +92,7 @@ module Dalli
         Dalli.logger.error "You are trying to cache a Ruby object which cannot be serialized to memcached."
         Dalli.logger.error ex.backtrace.join("\n\t")
         false
-      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
+      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, *TIMEOUT_ERRORS
         raise
       rescue => ex
         Dalli.logger.error "Unexpected exception during Dalli request: #{ex.class.name}: #{ex.message}"
@@ -192,7 +201,7 @@ module Dalli
       @position = pos
 
       values
-    rescue SystemCallError, Timeout::Error, EOFError => e
+    rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
       failure!(e)
     end
 
@@ -425,7 +434,7 @@ module Dalli
         marshalled = true
         begin
           self.serializer.dump(value)
-        rescue Timeout::Error => e
+        rescue *TIMEOUT_ERRORS => e
           raise e
         rescue => ex
           # Marshalling can throw several different types of generic Ruby exceptions.
@@ -572,7 +581,7 @@ module Dalli
         result = @sock.write(bytes)
         @inprogress = false
         result
-      rescue SystemCallError, Timeout::Error => e
+      rescue SystemCallError, *TIMEOUT_ERRORS => e
         failure!(e)
       end
     end
@@ -583,7 +592,7 @@ module Dalli
         data = @sock.readfull(count)
         @inprogress = false
         data
-      rescue SystemCallError, Timeout::Error, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         failure!(e)
       end
     end
@@ -607,7 +616,7 @@ module Dalli
         up!
       rescue Dalli::DalliError # SASL auth failure
         raise
-      rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError, SocketError => e
         # SocketError = DNS resolution failure
         failure!(e)
       end

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -64,7 +64,7 @@ begin
       sock.server = server
       sock.kgio_wait_writable
       sock
-    rescue Timeout::Error
+    rescue *Dalli::Server::TIMEOUT_ERRORS
       sock.close if sock
       raise
     end
@@ -78,7 +78,7 @@ begin
       sock.server = server
       sock.kgio_wait_writable
       sock
-    rescue Timeout::Error
+    rescue *Dalli::Server::TIMEOUT_ERRORS
       sock.close if sock
       raise
     end

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -28,7 +28,7 @@ begin
     alias :write :kgio_write
 
     def readfull(count)
-      value = String.new('')
+      value = String.new(capacity: count + 1)
       while true
         value << kgio_read!(count - value.bytesize)
         break if value.bytesize == count
@@ -95,7 +95,7 @@ rescue LoadError
   module Dalli::Server::KSocket
     module InstanceMethods
       def readfull(count)
-        value = String.new('')
+        value = String.new(capacity: count + 1)
         begin
           while true
             value << read_nonblock(count - value.bytesize)

--- a/test/test_sasl.rb
+++ b/test/test_sasl.rb
@@ -88,16 +88,16 @@ describe 'Sasl' do
 
     it 'pass SASL as URI' do
       Dalli::Server.expects(:new).with("localhost:19124",
-        :username => "testuser", :password => "testtest").returns(@server)
+        { :username => "testuser", :password => "testtest" }).returns(@server)
       dc = Dalli::Client.new('memcached://testuser:testtest@localhost:19124')
       dc.flush_all
     end
 
     it 'pass SASL as ring of URIs' do
       Dalli::Server.expects(:new).with("localhost:19124",
-        :username => "testuser", :password => "testtest").returns(@server)
+        { :username => "testuser", :password => "testtest" }).returns(@server)
       Dalli::Server.expects(:new).with("otherhost:19125",
-        :username => "testuser2", :password => "testtest2").returns(@server)
+        { :username => "testuser2", :password => "testtest2" }).returns(@server)
       dc = Dalli::Client.new(['memcached://testuser:testtest@localhost:19124',
       'memcached://testuser2:testtest2@otherhost:19125'])
       dc.flush_all

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -91,10 +91,10 @@ describe Dalli::Server do
     end
 
     it 'throws an exception if the hostname cannot be parsed' do
-      lambda { Dalli::Server.new('[]') }.must_raise Dalli::DalliError
-      lambda { Dalli::Server.new('my.fqdn.com:') }.must_raise Dalli::DalliError
-      lambda { Dalli::Server.new('my.fqdn.com:11212,:2') }.must_raise Dalli::DalliError
-      lambda { Dalli::Server.new('my.fqdn.com:11212:abc') }.must_raise Dalli::DalliError
+      expect(-> { Dalli::Server.new('[]') }).must_raise Dalli::DalliError
+      expect(-> { Dalli::Server.new('my.fqdn.com:') }).must_raise Dalli::DalliError
+      expect(-> { Dalli::Server.new('my.fqdn.com:11212,:2') }).must_raise Dalli::DalliError
+      expect(-> { Dalli::Server.new('my.fqdn.com:11212:abc') }).must_raise Dalli::DalliError
     end
   end
 
@@ -142,9 +142,9 @@ describe Dalli::Server do
       s = Dalli::Server.new('127.0.0.1', :error_when_over_max_size => true)
       value = OpenStruct.new(:bytesize => 1_048_577)
 
-      lambda do
+      expect(lambda do
         s.send(:guard_max_value, :foo, value)
-      end.must_raise Dalli::ValueOverMaxSize
+      end).must_raise Dalli::ValueOverMaxSize
     end
   end
 

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'ostruct'
 require_relative 'helper'
 
 describe Dalli::Server do


### PR DESCRIPTION
This fixes some warnings that make the tests hard to read

and backports changes from upstream:

- https://github.com/petergoldstein/dalli/commit/8e7815415e8f1a9c966859bc2177f84f38c16c74
- https://github.com/petergoldstein/dalli/pull/936
- https://github.com/petergoldstein/dalli/pull/953
- https://github.com/petergoldstein/dalli/pull/973

This **does not** make this forked version of Dalli run the `platform` specs much faster