### PR TITLE
Backport removal of `kgio` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'appraisal'
-gem 'kgio', :platform => :mri
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
       thor (>= 0.14.0)
     connection_pool (2.4.1)
     docile (1.4.0)
-    kgio (2.11.4)
     minitest (5.22.3)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
@@ -35,7 +34,6 @@ DEPENDENCIES
   appraisal
   connection_pool
   dalli!
-  kgio
   minitest
   mocha
   rack (~> 2.0, >= 2.2.0)

--- a/lib/dalli/compressor.rb
+++ b/lib/dalli/compressor.rb
@@ -15,7 +15,7 @@ module Dalli
 
   class GzipCompressor
     def self.compress(data)
-      io = StringIO.new(String.new(""), "w")
+      io = StringIO.new(+"", "w")
       gz = Zlib::GzipWriter.new(io)
       gz.write(data)
       gz.close

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -146,7 +146,7 @@ module Dalli
     def multi_response_start
       verify_state
       write_noop
-      @multi_buffer = String.new('')
+      @multi_buffer = +""
       @position = 0
       @inprogress = true
     end
@@ -182,7 +182,7 @@ module Dalli
           break
 
         elsif buf.bytesize - pos >= 24 + body_length
-          flags = buf.slice(pos + 24, 4).unpack('N')[0]
+          flags = buf.slice(pos + 24, 4).unpack1('N')
           key = buf.slice(pos + 24 + 4, key_length)
           value = buf.slice(pos + 24 + 4 + key_length, body_length - key_length - 4) if body_length - key_length - 4 > 0
 
@@ -292,7 +292,7 @@ module Dalli
     end
 
     def send_multiget(keys)
-      req = String.new("")
+      req = +""
       keys.each do |key|
         req << [REQUEST, OPCODES[:getkq], key.bytesize, 0, 0, 0, key.bytesize, 0, 0, key].pack(FORMAT[:getkq])
       end
@@ -357,7 +357,7 @@ module Dalli
       req = [REQUEST, OPCODES[opcode], key.bytesize, 20, 0, 0, key.bytesize + 20, 0, 0, h, l, dh, dl, expiry, key].pack(FORMAT[opcode])
       write(req)
       body = generic_response
-      body ? body.unpack('Q>').first : body
+      body ? body.unpack1('Q>') : body
     end
 
     def decr(key, count, ttl, default)
@@ -485,7 +485,7 @@ module Dalli
       elsif status != 0
         raise Dalli::DalliError, "Response error #{status}: #{RESPONSE_CODES[status]}"
       elsif data
-        flags = data[0...extras].unpack('N')[0]
+        flags = data[0...extras].unpack1('N')
         value = data[extras..-1]
         data = deserialize(value, flags)
       end
@@ -534,7 +534,7 @@ module Dalli
       elsif status != 0
         raise Dalli::DalliError, "Response error #{status}: #{RESPONSE_CODES[status]}"
       elsif data
-        flags = data[0...extras].unpack('N')[0]
+        flags = data[0...extras].unpack1('N')
         value = data[extras..-1]
         unpack ? deserialize(value, flags) : value
       else
@@ -558,7 +558,7 @@ module Dalli
 
     def keyvalue_response
       hash = {}
-      while true
+      loop do
         (key_length, _, body_length, _) = read_header.unpack(KV_HEADER)
         return hash if key_length == 0
         key = read(key_length)
@@ -568,7 +568,7 @@ module Dalli
     end
 
     def flush_response
-      while true
+      loop do
         (key_length, status, body_length, _) = read_header.unpack(KV_HEADER)
         return if key_length == 0 && status == 0
         read(body_length) if body_length > 0
@@ -606,10 +606,10 @@ module Dalli
 
       begin
         @pid = PIDCache.pid
-        if socket_type == :unix
-          @sock = KSocket::UNIX.open(hostname, self, options)
+        @sock = if socket_type == :unix
+          Dalli::Socket::UNIX.open(hostname, self, options)
         else
-          @sock = KSocket::TCP.open(hostname, port, self, options)
+          Dalli::Socket::TCP.open(hostname, port, self, options)
         end
         sasl_authentication if need_auth?
         @version = version # trigger actual connect
@@ -752,7 +752,7 @@ module Dalli
       res = str.match(/\A(\[([\h:]+)\]|[^:]+)(?::(\d+))?(?::(\d+))?\z/)
       raise Dalli::DalliError, "Could not parse hostname #{str}" if res.nil? || res[1] == '[]'
       hostnam = res[2] || res[1]
-      if hostnam =~ /\A\//
+      if hostnam.start_with?("/")
         socket_type = :unix
         # in case of unix socket, allow only setting of weight, not port
         raise Dalli::DalliError, "Could not parse hostname #{str}" if res[4]

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -1,170 +1,78 @@
 # frozen_string_literal: true
-require 'rbconfig'
 
-module Dalli::Server::TCPSocketOptions
-  def setsockopts(sock, options)
-    sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
-    sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true) if options[:keepalive]
-    sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, options[:rcvbuf]) if options[:rcvbuf]
-    sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, options[:sndbuf]) if options[:sndbuf]
-  end
-end
-
-begin
-  require 'kgio'
-  puts "Using kgio socket IO" if defined?($TESTING) && $TESTING
-
-  class Dalli::Server::KSocket < Kgio::Socket
-    attr_accessor :options, :server
-
-    def kgio_wait_readable
-      IO.select([self], nil, nil, options[:socket_timeout]) || raise(Timeout::Error, "IO timeout")
-    end
-
-    def kgio_wait_writable
-      IO.select(nil, [self], nil, options[:socket_timeout]) || raise(Timeout::Error, "IO timeout")
-    end
-
-    alias :write :kgio_write
-
-    def readfull(count)
-      value = String.new(capacity: count + 1)
-      while true
-        value << kgio_read!(count - value.bytesize)
-        break if value.bytesize == count
-      end
-      value
-    end
-
-    def read_available
-      value = String.new('')
-      while true
-        ret = kgio_tryread(8196)
-        case ret
-        when nil
-          raise EOFError, 'end of stream'
-        when :wait_readable
-          break
-        else
-          value << ret
-        end
-      end
-      value
-    end
-  end
-
-  class Dalli::Server::KSocket::TCP < Dalli::Server::KSocket
-    extend Dalli::Server::TCPSocketOptions
-
-    def self.open(host, port, server, options = {})
-      addr = Socket.pack_sockaddr_in(port, host)
-      sock = start(addr)
-      setsockopts(sock, options)
-      sock.options = options
-      sock.server = server
-      sock.kgio_wait_writable
-      sock
-    rescue *Dalli::Server::TIMEOUT_ERRORS
-      sock.close if sock
-      raise
-    end
-  end
-
-  class Dalli::Server::KSocket::UNIX < Dalli::Server::KSocket
-    def self.open(path, server, options = {})
-      addr = Socket.pack_sockaddr_un(path)
-      sock = start(addr)
-      sock.options = options
-      sock.server = server
-      sock.kgio_wait_writable
-      sock
-    rescue *Dalli::Server::TIMEOUT_ERRORS
-      sock.close if sock
-      raise
-    end
-  end
-
-  if ::Kgio.respond_to?(:wait_readable=)
-    ::Kgio.wait_readable = :kgio_wait_readable
-    ::Kgio.wait_writable = :kgio_wait_writable
-  end
-
-rescue LoadError
-
-  puts "Using standard socket IO (#{RUBY_DESCRIPTION})" if defined?($TESTING) && $TESTING
-  module Dalli::Server::KSocket
+module Dalli
+  module Socket
     module InstanceMethods
       def readfull(count)
         value = String.new(capacity: count + 1)
-        begin
-          while true
-            value << read_nonblock(count - value.bytesize)
-            break if value.bytesize == count
-          end
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
-          if IO.select([self], nil, nil, options[:socket_timeout])
-            retry
+        loop do
+          result = read_nonblock(count - value.bytesize, exception: false)
+          if result == :wait_readable
+            raise Timeout::Error, "IO timeout: #{safe_options.inspect}" unless IO.select([self], nil, nil, options[:socket_timeout])
+          elsif result == :wait_writable
+            raise Timeout::Error, "IO timeout: #{safe_options.inspect}" unless IO.select(nil, [self], nil, options[:socket_timeout])
+          elsif result
+            value << result
           else
-            safe_options = options.reject{|k,v| [:username, :password].include? k}
-            raise Timeout::Error, "IO timeout: #{safe_options.inspect}"
+            raise Errno::ECONNRESET, "Connection reset: #{safe_options.inspect}"
           end
+          break if value.bytesize == count
         end
         value
       end
 
       def read_available
-        value = String.new('')
-        while true
-          begin
-            value << read_nonblock(8196)
-          rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+        value = +""
+        loop do
+          result = read_nonblock(8196, exception: false)
+          if result == :wait_readable
             break
+          elsif result == :wait_writable
+            break
+          elsif result
+            value << result
+          else
+            raise Errno::ECONNRESET, "Connection reset: #{safe_options.inspect}"
           end
         end
         value
       end
-    end
 
-    def self.included(receiver)
-      receiver.send(:attr_accessor, :options, :server)
-      receiver.send(:include, InstanceMethods)
-    end
-  end
-
-  class Dalli::Server::KSocket::TCP < TCPSocket
-    extend Dalli::Server::TCPSocketOptions
-    include Dalli::Server::KSocket
-
-    def self.open(host, port, server, options = {})
-      Timeout.timeout(options[:socket_timeout]) do
-        sock = new(host, port)
-        setsockopts(sock, options)
-        sock.options = {:host => host, :port => port}.merge(options)
-        sock.server = server
-        sock
+      def safe_options
+        options.reject { |k, v| [:username, :password].include? k }
       end
     end
-  end
 
-  if RbConfig::CONFIG['host_os'] =~ /mingw|mswin/
-    class Dalli::Server::KSocket::UNIX
-      def initialize(*args)
-        raise Dalli::DalliError, "Unix sockets are not supported on Windows platform."
-      end
-    end
-  else
-    class Dalli::Server::KSocket::UNIX < UNIXSocket
-      include Dalli::Server::KSocket
+    class TCP < TCPSocket
+      include Dalli::Socket::InstanceMethods
+      attr_accessor :options, :server
 
-      def self.open(path, server, options = {})
+      def self.open(host, port, server, options = {})
         Timeout.timeout(options[:socket_timeout]) do
-          sock = new(path)
-          sock.options = {:path => path}.merge(options)
+          sock = new(host, port)
+          sock.options = {host: host, port: port}.merge(options)
           sock.server = server
+          sock.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, true) if options[:keepalive]
+          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_RCVBUF, options[:rcvbuf]) if options[:rcvbuf]
+          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_SNDBUF, options[:sndbuf]) if options[:sndbuf]
           sock
         end
       end
     end
 
+    class UNIX < UNIXSocket
+      include Dalli::Socket::InstanceMethods
+      attr_accessor :options, :server
+
+      def self.open(path, server, options = {})
+        Timeout.timeout(options[:socket_timeout]) do
+          sock = new(path)
+          sock.options = {path: path}.merge(options)
+          sock.server = server
+          sock
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Backports the removal of the `kgio` gem (Kinder, Gentler IO)

Will merge into:
- https://github.com/braze-inc/dalli/pull/10
- https://github.com/braze-inc/dalli/pull/9

This **DOES** make this forked version of Dalli run the `platform` specs at pretty much the same speed as in Ruby 3.2

- https://github.com/petergoldstein/dalli/commit/2277c163f5562cd53fa1a9e122c1a7d54ba1c5f3
- https://github.com/petergoldstein/dalli/commit/3003d5af1945538c5ce13417eb058425020609ba