### PR TITLE
Revert - Only lock servers involved in get_multi #4

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -431,16 +431,17 @@ module Dalli
     def get_multi_yielder(keys)
       perform do
         return {} if keys.empty?
-        groups = groups_for_keys(keys)
-        servers = groups.keys
-        return if servers.empty?
-        ring.lock(servers) do
+        ring.lock do
           begin
+            groups = groups_for_keys(keys)
+
             if unfound_keys = groups.delete(nil)
               Dalli.logger.debug { "unable to get keys for #{unfound_keys.length} keys because no matching server was found" }
             end
             make_multi_get_requests(groups)
 
+            servers = groups.keys
+            return if servers.empty?
             servers = perform_multi_response_start(servers)
 
             start = Time.now

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -53,13 +53,12 @@ module Dalli
       raise Dalli::RingError, "No server available"
     end
 
-    def lock(servers)
-      locked_servers = servers.dup.compact # make a copy, since the argument may be mutated after locking
-      locked_servers.each(&:lock!)
+    def lock
+      @servers.each(&:lock!)
       begin
         return yield
       ensure
-        locked_servers.each(&:unlock!)
+        @servers.each(&:unlock!)
       end
     end
 


### PR DESCRIPTION
This update makes this Dalli fork match the upstream definition of `Ring#lock` again https://github.com/petergoldstein/dalli/blob/e5378846becf6382e6ca38b24ac89ff2ec88e8df/lib/dalli/ring.rb#L75-L82

I wonder if the partial locking was allowing deadlock, something like:

```
Given threads A,B and ring member servers S1,S2

A needs to lock S1, S2
B needs to lock S2, S1

A locks S1, B locks S2 at the same time

A waits for S2, B waits for S1 => deadlock, super-long APM trace before Sidekiq forcibly kills the worker
```

---

Manual revert of #4

![image](https://github.com/user-attachments/assets/f4229155-9728-4df0-b4fa-70993be13f5a)
