### PR TITLE
Add codeowner to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @braze-inc/sidekiq-and-monolith-foundations


### PR DESCRIPTION
SMF is marked as the owner of the `dalli` gem in `platform`, so I think they ought to be the CODEOWNERS of this repo

https://github.com/Appboy/platform/blob/911e23f40aacc81c1256a6220c1b400fd74fb107/dashboard/Gemfile#L69