### PR TITLE
Revert some cherry-picked changes to try to get `platform` to Ruby 3.3

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -50,7 +50,6 @@ module Dalli
       old, Thread.current[:dalli_multi] = Thread.current[:dalli_multi], true
       yield
     ensure
-      @ring&.flush_multi_responses
       Thread.current[:dalli_multi] = old
     end
 
@@ -318,24 +317,17 @@ module Dalli
     end
 
     def perform_multi_response_start(servers)
-      deleted = []
-
       servers.each do |server|
-        next unless !server.nil? && server.alive?
-
+        next unless server.alive?
         begin
           server.multi_response_start
-        rescue Dalli::NetworkError
-          servers.each { |s| s.multi_response_abort unless s.sock.nil?  }
-          raise
-        rescue Dalli::DalliError => e
+        rescue DalliError, NetworkError => e
           Dalli.logger.debug { e.inspect }
           Dalli.logger.debug { "results from this server will be missing" }
-          deleted.append(server)
+          servers.delete(server)
         end
       end
-
-      servers.delete_if { |server| deleted.include?(server) }
+      servers
     end
 
     ##
@@ -369,13 +361,12 @@ module Dalli
 
     # Chokepoint method for instrumentation
     def perform(*all_args)
+      return yield if block_given?
+      op, key, *args = *all_args
+
+      key = key.to_s
+      key = validate_key(key)
       begin
-        return yield if block_given?
-        op, key, *args = all_args
-
-        key = key.to_s
-        key = validate_key(key)
-
         server = ring.server_for_key(key)
         ret = server.request(op, key, *args)
         ret
@@ -434,7 +425,6 @@ module Dalli
         ring.lock do
           begin
             groups = groups_for_keys(keys)
-
             if unfound_keys = groups.delete(nil)
               Dalli.logger.debug { "unable to get keys for #{unfound_keys.length} keys because no matching server was found" }
             end
@@ -447,7 +437,7 @@ module Dalli
             start = Time.now
             while true
               # remove any dead servers
-              servers.delete_if { |s| s.nil? || s.sock.nil? }
+              servers.delete_if { |s| s.sock.nil? }
               break if servers.empty?
 
               # calculate remaining timeout
@@ -479,8 +469,7 @@ module Dalli
                       servers.delete(server)
                     end
                   rescue NetworkError
-                    servers.each { |s| s.multi_response_abort unless s.sock.nil? }
-                    raise
+                    servers.delete(server)
                   end
                 end
               end

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -62,15 +62,6 @@ module Dalli
       end
     end
 
-    def flush_multi_responses
-      @servers.each do |s|
-        s.request(:noop)
-      rescue Dalli::NetworkError
-        # Ignore this error, as it indicates the socket is unavailable
-        # and there's no need to flush
-      end
-    end
-
     private
 
     def threadsafe!

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -17,13 +17,13 @@ module Dalli
     DEFAULT_WEIGHT = 1
     DEFAULTS = {
       # seconds between trying to contact a remote server
-      :down_retry_delay => 30,
+      :down_retry_delay => 60,
       # connect/read/write timeout for socket operations
-      :socket_timeout => 1,
+      :socket_timeout => 0.5,
       # times a socket operation may fail before considering the server dead
       :socket_max_failures => 2,
       # amount of time to sleep between retries when a failure occurs
-      :socket_failure_delay => 0.1,
+      :socket_failure_delay => 0.01,
       # max size of value in bytes (default is 1 MB, can be overriden with "memcached -I <size>")
       :value_max_bytes => 1024 * 1024,
       # surpassing value_max_bytes either warns (false) or throws (true)
@@ -44,15 +44,6 @@ module Dalli
     }
 
     ALLOWED_MULTI_OPS = %i[set setq delete deleteq add addq replace replaceq].freeze
-
-    # Ruby 3.2 raises IO::TimeoutError on blocking reads/writes, but
-    # it is not defined in earlier Ruby versions.
-    TIMEOUT_ERRORS =
-      if defined?(IO::TimeoutError)
-        [Timeout::Error, IO::TimeoutError]
-      else
-        [Timeout::Error]
-      end
 
     def initialize(attribs, options = {})
       @hostname, @port, @weight, @socket_type = parse_hostname(attribs)
@@ -92,7 +83,7 @@ module Dalli
         Dalli.logger.error "You are trying to cache a Ruby object which cannot be serialized to memcached."
         Dalli.logger.error ex.backtrace.join("\n\t")
         false
-      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, *TIMEOUT_ERRORS
+      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
         raise
       rescue => ex
         Dalli.logger.error "Unexpected exception during Dalli request: #{ex.class.name}: #{ex.message}"
@@ -146,7 +137,7 @@ module Dalli
     def multi_response_start
       verify_state
       write_noop
-      @multi_buffer = +""
+      @multi_buffer = String.new('')
       @position = 0
       @inprogress = true
     end
@@ -163,7 +154,7 @@ module Dalli
     #
     # Returns a Hash of kv pairs received.
     def multi_response_nonblock
-      reconnect! 'multi_response has completed' if @multi_buffer.nil?
+      raise 'multi_response has completed' if @multi_buffer.nil?
 
       @multi_buffer << @sock.read_available
       buf = @multi_buffer
@@ -201,7 +192,7 @@ module Dalli
       @position = pos
 
       values
-    rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+    rescue SystemCallError, Timeout::Error, EOFError => e
       failure!(e)
     end
 
@@ -434,7 +425,7 @@ module Dalli
         marshalled = true
         begin
           self.serializer.dump(value)
-        rescue *TIMEOUT_ERRORS => e
+        rescue Timeout::Error => e
           raise e
         rescue => ex
           # Marshalling can throw several different types of generic Ruby exceptions.
@@ -581,7 +572,7 @@ module Dalli
         result = @sock.write(bytes)
         @inprogress = false
         result
-      rescue SystemCallError, *TIMEOUT_ERRORS => e
+      rescue SystemCallError, Timeout::Error => e
         failure!(e)
       end
     end
@@ -592,7 +583,7 @@ module Dalli
         data = @sock.readfull(count)
         @inprogress = false
         data
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+      rescue SystemCallError, Timeout::Error, EOFError => e
         failure!(e)
       end
     end
@@ -616,7 +607,7 @@ module Dalli
         up!
       rescue Dalli::DalliError # SASL auth failure
         raise
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError, SocketError => e
+      rescue SystemCallError, Timeout::Error, EOFError, SocketError => e
         # SocketError = DNS resolution failure
         failure!(e)
       end


### PR DESCRIPTION
I had cherry-picked several upstream changes into our fork before finding that `kgio` was the reason for slowness in CI with Ruby 3.3

This reverts changes that are not `kgio`, not dalli CI, and not simple performance optimizations.

I noticed some memcached metrics were looking out of the ordinary when this was causing problems in US-05, CPU is pegged way higher than normal, but also [the `total_connections_rate` and `curr_connections` were elevated](https://app.datadoghq.com/metric/explorer?fromUser=true&graph_layout=multi&start=1747053190316&end=1747063996456&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMjqqpkYmWwAdAg4CBhoTplSInCZEo5O2p5wwJloeBoIOpHqyADWABwaTeOT09oAtAAM2wCsTfKbk3CbZE0ARsMAXnCrOKo8AAQXWE-A83gXcGnt04J4NBaBBNT7fbS9aYrSQAegcUE2szgPBAfFASJipSwACZEsl2mkMtllPlCsUQLEaLlKtVavVGndMnhtNouj0+gMRBoxhMpjMonAFstVryNjt9odjlozpcboyHs9Xu8wT8piMAUDEKCvjNEJomrD4YiBSi0REBZidFgAMx4lKE5nE3KkiBFRKU8pVZDdETtUQ6VbyPBNSYYeA89b8uZLFZrPlbXYHI4nGVXDC3e6qChPFVs30Yf2spHIeSYBCudybOkNNhQRVvD4637qwHA7XgyH6w04BFI00UdEW3KUgAsdoJ6UdOTyiDJ7qxnuqPr9vW0geDofDcY2xZjIsjCYlyel5zTGe6WZzTeXBdXTmLpc8FdUVbgdRrcDrLwbubV-1bWoqhCerQjgcI9sa6imgAulQz6AhgoThPBmCWnECRmihGBoTiqIDiAWE4bamFuKoCE4WOPCwSAUxYGgOSgPIHSINMyhQDgMBdJgGgaK6iRoP6ThyIoyjpAJUD8YJ9BMMoIikR0eFJBA9iYFgQkKNOAm9Ki0E8HwNGluIADCUjCDAKAiICaA8EAA).
![image](https://github.com/user-attachments/assets/c6be01da-4782-42db-a367-d82f8b17a954)
(deployed change around 09:00 and errors appeared shortly after 10:00).

Some of the changes here would possibly cause `reconnect` more often, and maybe memcached wasn't able to handle that.

This is the diff from what is working in production today, and this branch:
https://github.com/braze-inc/dalli/compare/v2.7.11-braze-2...revert-some-recent-changes?w=1