### PR TITLE
[FOUND-112][IRT-666] Close open connections on Timeout::Error

### DIFF
--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -83,7 +83,21 @@ module Dalli
         Dalli.logger.error "You are trying to cache a Ruby object which cannot be serialized to memcached."
         Dalli.logger.error ex.backtrace.join("\n\t")
         false
-      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
+      rescue Timeout::Error
+        # A Timeout::Error can be injected asynchronously by Thread#raise
+        # (from Timeout.timeout's watchdog thread) at ANY point in execution.
+        # If it fires between write(req) and reading the response for ANY
+        # operation (GET, SET, DELETE, etc.), the server's response remains
+        # in the socket's receive buffer. Without closing, the next operation
+        # reads those stale bytes as if they were its own response.
+        #
+        # Closing the socket discards any potentially stale data and forces
+        # a fresh connection on the next operation. This may occasionally
+        # close a clean socket (if the timeout fired at a "safe" point), but
+        # the performance cost of an extra reconnect is negligible.
+        close
+        raise
+      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize
         raise
       rescue => ex
         Dalli.logger.error "Unexpected exception during Dalli request: #{ex.class.name}: #{ex.message}"


### PR DESCRIPTION
A possible remedy to IRT-666.

dalli uses the Ruby `Timeout` module which is [known to be problematic](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/). Working with Claude suggests that these problems can impact our fork of dalli, causing data corruption — here's how that happens:

* `Timeout.timeout` is [used in socket.rb](https://github.com/braze-inc/dalli/blob/26f61f87199753346c9cae20307d70a36b226eec/lib/dalli/socket.rb#L51-L60) when opening a TCP or Unix socket. It creates a new Thread which will raise an exception in the main thread after waiting `:socket_timeout` seconds to open that socket.
* The exception can land _anywhere_ back in the main thread—in the middle of an ensure block, inside a cleanup routine, or critically, **while dalli is reading from a socket**.
* Furthermore, there is a `TOCTOU` race condition in play here: the `Timeout.timeout` watchdog may fire slightly late, after the connection has been successfully opened and used to perform the requested operation (e.g. GET the value at a key)
* When this happens, a Timeout::Error is raised and [rescued in the Server#request method](https://github.com/braze-inc/dalli/blob/e59be2299537bf604a37ccc838d119c6b23d95ba/lib/dalli/server.rb#L71-L107). Without this change, the error is just reraised and the connection is never properly closed, **leaving stale data in the socket which is read by the next request.**
* The Ruby code tries to call unavailable methods on this unexpected data, creating exceptions and issue events in Sentry.

By closing the socket after a `Timeout::Error` is rescued, we should avoid the data corruption errors we have seen sporadically across clusters.