### PR TITLE
[NOTIX] Remove failing tests that should have been cleaned up

### DIFF
--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -212,24 +212,4 @@ describe Dalli::Server do
       end
     end
   end
-
-  describe 'multi_response_nonblock' do
-    subject { Dalli::Server.new('127.0.0.1') }
-
-    it 'raises NetworkError when called before multi_response_start' do
-      assert_raises Dalli::NetworkError do
-        subject.request(:send_multiget, ['a', 'b'])
-        subject.multi_response_nonblock
-      end
-    end
-
-    it 'raises NetworkError when called after multi_response_abort' do
-      assert_raises Dalli::NetworkError do
-        subject.request(:send_multiget, ['a', 'b'])
-        subject.multi_response_start
-        subject.multi_response_abort
-        subject.multi_response_nonblock
-      end
-    end
-  end
 end


### PR DESCRIPTION
* These tests were added as part of a backporting PR - https://github.com/braze-inc/dalli/pull/10
* The tests would pass because of this change to server.rb - https://github.com/braze-inc/dalli/pull/10/changes#diff-939d6b009211086f291333fe88bd7842f9cea70125e8b3e89969eb8748fdc8c8R166
* That change to server.rb was reverted in this follow-up PR - https://github.com/braze-inc/dalli/pull/15/changes#diff-939d6b009211086f291333fe88bd7842f9cea70125e8b3e89969eb8748fdc8c8R157
* The tests were never removed, so they lived on and continued failing.
* No one noticed because this fork doesn't run tests or anything else as part of CI, so I'm adding that in this follow-up PR: https://github.com/braze-inc/dalli/pull/21. With these tests removed, that CI passes all tests successfully 🎉 
