### PR TITLE
Add test coverage for Dalli module

### DIFF
--- a/test/test_dalli_module.rb
+++ b/test/test_dalli_module.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+describe 'Dalli module' do
+  describe 'version' do
+    it 'is defined' do
+      refute_nil Dalli::VERSION
+    end
+
+    it 'is a string' do
+      assert_kind_of String, Dalli::VERSION
+    end
+  end
+
+  describe 'error classes' do
+    it 'defines DalliError as a RuntimeError' do
+      assert Dalli::DalliError < RuntimeError
+    end
+
+    it 'defines NetworkError as a DalliError' do
+      assert Dalli::NetworkError < Dalli::DalliError
+    end
+
+    it 'defines RingError as a DalliError' do
+      assert Dalli::RingError < Dalli::DalliError
+    end
+
+    it 'defines MarshalError as a DalliError' do
+      assert Dalli::MarshalError < Dalli::DalliError
+    end
+
+    it 'defines UnmarshalError as a DalliError' do
+      assert Dalli::UnmarshalError < Dalli::DalliError
+    end
+
+    it 'defines ValueOverMaxSize as a DalliError' do
+      assert Dalli::ValueOverMaxSize < Dalli::DalliError
+    end
+  end
+
+  describe 'logger' do
+    after do
+      Dalli.logger = Logger.new(STDOUT)
+      Dalli.logger.level = Logger::ERROR
+    end
+
+    it 'has a default logger' do
+      Dalli.instance_variable_set(:@logger, nil)
+      refute_nil Dalli.logger
+    end
+
+    it 'allows setting a custom logger' do
+      custom = Logger.new(nil)
+      Dalli.logger = custom
+      assert_equal custom, Dalli.logger
+    end
+
+    it 'default_logger creates an INFO-level STDOUT logger' do
+      logger = Dalli.default_logger
+      assert_equal Logger::INFO, logger.level
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds unit tests for the top-level `Dalli` module:

- `VERSION` constant: defined and is a String
- Error class hierarchy: `DalliError`, `NetworkError`, `RingError`, `MarshalError`, `UnmarshalError`, `ValueOverMaxSize`
- Logger: default logger creation, custom logger assignment, `default_logger` level

Made with [Cursor](https://cursor.com)

This is one of a handful of PRs adding missing test coverage to dalli:
- https://github.com/braze-inc/dalli/pull/27
- https://github.com/braze-inc/dalli/pull/28
- https://github.com/braze-inc/dalli/pull/29
- https://github.com/braze-inc/dalli/pull/30
- https://github.com/braze-inc/dalli/pull/31
- https://github.com/braze-inc/dalli/pull/32