### PR TITLE
Add test coverage for Dalli::PIDCache

### DIFF
--- a/test/test_pid_cache.rb
+++ b/test/test_pid_cache.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+describe Dalli::PIDCache do
+  it 'returns the current process PID' do
+    assert_equal Process.pid, Dalli::PIDCache.pid
+  end
+
+  it 'responds to .pid' do
+    assert_respond_to Dalli::PIDCache, :pid
+  end
+
+  if Process.respond_to?(:_fork)
+    describe 'on Ruby 3.1+ with Process._fork' do
+      it 'responds to update!' do
+        assert_respond_to Dalli::PIDCache, :update!
+      end
+
+      it 'updates pid to match Process.pid' do
+        Dalli::PIDCache.update!
+        assert_equal Process.pid, Dalli::PIDCache.pid
+      end
+
+      it 'has CoreExt prepended on Process' do
+        assert Process.singleton_class.ancestors.include?(Dalli::PIDCache::CoreExt)
+      end
+
+      if Process.respond_to?(:fork)
+        it 'resets pid cache in child after fork' do
+          parent_pid = Process.pid
+
+          rd, wr = IO.pipe
+          child_pid = Process.fork do
+            rd.close
+            wr.write Dalli::PIDCache.pid.to_s
+            wr.close
+          end
+          wr.close
+          cached_pid_in_child = rd.read.to_i
+          rd.close
+          Process.wait(child_pid)
+
+          assert_equal child_pid, cached_pid_in_child
+          refute_equal parent_pid, cached_pid_in_child
+        end
+      end
+    end
+  elsif !Process.respond_to?(:fork)
+    describe 'on JRuby/TruffleRuby without fork' do
+      it 'returns a fixed pid' do
+        assert_equal Process.pid, Dalli::PIDCache.pid
+      end
+    end
+  else
+    describe 'on Ruby 3.0 or older' do
+      it 'delegates directly to Process.pid' do
+        assert_equal Process.pid, Dalli::PIDCache.pid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds unit tests for `Dalli::PIDCache`:

- Basic PID caching and `.pid` interface
- Ruby 3.1+ (`Process._fork`): `update!`, `CoreExt` prepended on `Process`, child PID reset after fork
- Platform fallbacks for JRuby/TruffleRuby and Ruby 3.0 or older

Made with [Cursor](https://cursor.com)