### PR TITLE
Add missing test coverage for Dalli::Ring

### DIFF
--- a/test/test_ring.rb
+++ b/test/test_ring.rb
@@ -83,4 +83,83 @@ describe 'Ring' do
       end
     end
   end
+
+  describe 'Ring::Entry' do
+    it 'stores value and server' do
+      server = stub(:name => 'localhost:11211')
+      entry = Dalli::Ring::Entry.new(12345, server)
+      assert_equal 12345, entry.value
+      assert_equal server, entry.server
+    end
+  end
+
+  describe 'continuum with weighted servers' do
+    it 'gives more entries to higher-weight servers' do
+      light = stub(:name => 'light:11211', :weight => 1)
+      heavy = stub(:name => 'heavy:11211', :weight => 3)
+      ring = Dalli::Ring.new([light, heavy], {})
+
+      light_count = ring.continuum.count { |e| e.server == light }
+      heavy_count = ring.continuum.count { |e| e.server == heavy }
+      assert_operator heavy_count, :>, light_count
+    end
+
+    it 'produces proportional entry counts' do
+      s1 = stub(:name => 'a:11211', :weight => 1)
+      s2 = stub(:name => 'b:11211', :weight => 2)
+      ring = Dalli::Ring.new([s1, s2], {})
+
+      s1_count = ring.continuum.count { |e| e.server == s1 }
+      s2_count = ring.continuum.count { |e| e.server == s2 }
+      ratio = s2_count.to_f / s1_count
+      assert_in_delta 2.0, ratio, 0.1
+    end
+  end
+
+  describe 'failover disabled' do
+    it 'raises RingError immediately when failover is false and server is down' do
+      servers = [
+        Dalli::Server.new("localhost:12345"),
+        Dalli::Server.new("localhost:12346"),
+      ]
+      ring = Dalli::Ring.new(servers, { failover: false })
+      assert_raises Dalli::RingError do
+        ring.server_for_key('test')
+      end
+    end
+  end
+
+  describe 'lock' do
+    it 'locks and unlocks all servers around a block' do
+      s1 = stub(:name => 'a:11211', :weight => 1)
+      s2 = stub(:name => 'b:11211', :weight => 1)
+      s1.expects(:lock!)
+      s1.expects(:unlock!)
+      s2.expects(:lock!)
+      s2.expects(:unlock!)
+      ring = Dalli::Ring.new([s1, s2], { threadsafe: false })
+
+      result = ring.lock { 42 }
+      assert_equal 42, result
+    end
+
+    it 'unlocks servers even when block raises' do
+      s1 = stub(:name => 'a:11211', :weight => 1)
+      s1.expects(:lock!)
+      s1.expects(:unlock!)
+      ring = Dalli::Ring.new([s1], { threadsafe: false })
+
+      assert_raises RuntimeError do
+        ring.lock { raise RuntimeError, 'boom' }
+      end
+    end
+  end
+
+  describe 'single server without continuum' do
+    it 'does not create a continuum' do
+      server = stub(:name => 'localhost:11211', :weight => 1)
+      ring = Dalli::Ring.new([server], { threadsafe: false })
+      assert_nil ring.continuum
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds unit tests for `Dalli::Ring` behavior not previously covered:

- `Ring::Entry`: stores value and server reference
- Weighted servers: higher-weight servers get proportionally more continuum entries
- Failover disabled: raises `RingError` immediately when `failover: false`
- `lock`: acquires/releases locks on all servers around a block, unlocks on exception
- Single-server optimization: skips continuum creation for a single server

Made with [Cursor](https://cursor.com)