### PR TITLE
[NOTIX] Run test suite CI for all pull_requests, regardless of base branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test Suite
 
 on:
-  push:
-    branches: [ braze-main ]
   pull_request:
+  push:
     branches: [ braze-main ]
 
 jobs:


### PR DESCRIPTION
The chain of PRs which comprise https://github.com/braze-inc/dalli/pull/34 did not all run the CI test suite. This caused failing tests to slip through the cracks. After this change, all pull requests will run the test suite in the github workflow, not just those branching off from `braze-main`

After merge:
- [x] Merge braze-main into https://github.com/braze-inc/dalli/pull/35
- [ ] Push empty (`--allow-empty`) commits to open PRs to kick off the test suite workflow