### PR TITLE
[FOUND-113] Final meta protocol correctness and coverage pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 Dalli [![Build Status](https://secure.travis-ci.org/petergoldstein/dalli.svg)](http://travis-ci.org/petergoldstein/dalli)
 =====
 
-Dalli is a high performance pure Ruby client for accessing memcached servers.  It works with memcached 1.4+ only as it uses the newer binary protocol.  It should be considered a replacement for the memcache-client gem.
+Dalli is a high performance pure Ruby client for accessing memcached servers. It supports:
+
+* binary protocol (default, memcached 1.4+)
+* meta text protocol (`protocol: :meta`, memcached 1.6+)
+
+Meta protocol mode does not support SASL authentication. Dalli should be considered a replacement for the memcache-client gem.
 
 The name is a variant of Salvador Dali for his famous painting [The Persistence of Memory](http://en.wikipedia.org/wiki/The_Persistence_of_Memory).
 

--- a/lib/dalli/protocol/meta/key_regularizer.rb
+++ b/lib/dalli/protocol/meta/key_regularizer.rb
@@ -7,7 +7,8 @@ module Dalli
       # non-ASCII characters or whitespace are base64-encoded and sent with the
       # 'b' flag so the server knows to decode them.
       class KeyRegularizer
-        INVALID_META_KEY_CHARS = /[\s[:cntrl:]]/
+        # Memcached text/meta keys cannot contain control chars or spaces.
+        INVALID_META_KEY_CHARS = /[\x00-\x20\x7F]/
 
         def self.encode(key)
           return [key, false] if key.ascii_only? && !INVALID_META_KEY_CHARS.match?(key)
@@ -18,7 +19,9 @@ module Dalli
         def self.decode(encoded_key, base64_encoded)
           return encoded_key unless base64_encoded
 
-          encoded_key.unpack1('m0')
+          decoded = encoded_key.unpack1('m0')
+          utf8 = decoded.dup.force_encoding(Encoding::UTF_8)
+          utf8.valid_encoding? ? utf8 : decoded.force_encoding(Encoding::BINARY)
         end
       end
     end

--- a/test/test_dalli.rb
+++ b/test/test_dalli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'helper'
 require 'openssl'
+require 'dalli/protocol/meta'
 
 describe 'Dalli' do
   describe 'options parsing' do

--- a/test/test_meta_protocol.rb
+++ b/test/test_meta_protocol.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'helper'
 require 'dalli/protocol/meta'
+require 'dalli/cas/client'
 
 describe 'Dalli Meta Protocol' do
   # Use a dedicated port range for meta protocol tests
@@ -255,6 +256,61 @@ describe 'Dalli Meta Protocol' do
         result = dc.get_multi('mgo1', 'mgo2')
         assert_equal({a: 1}, result['mgo1'])
         assert_equal [1, 2, 3], result['mgo2']
+      end
+    end
+
+    it 'handles get_multi with keys requiring base64 encoding' do
+      memcached_meta_persistent do |dc|
+        unicode_key = +"meta_\xC3\xA9_key"
+        unicode_key.force_encoding(Encoding::UTF_8)
+        spaced_key = 'meta key with spaces'
+        tab_key = "meta\tkey\twith\ttabs"
+
+        dc.set(unicode_key, 'unicode-value')
+        dc.set(spaced_key, 'space-value')
+        dc.set(tab_key, 'tab-value')
+
+        result = dc.get_multi(unicode_key, spaced_key, tab_key)
+        assert_equal 'unicode-value', result[unicode_key]
+        assert_equal 'space-value', result[spaced_key]
+        assert_equal 'tab-value', result[tab_key]
+      end
+    end
+  end
+
+  describe 'CAS client API' do
+    it 'supports get_multi_cas, set_cas, replace_cas, and delete_cas' do
+      memcached_meta_persistent do |_, port|
+        dc = Dalli::Client.new(
+          ["localhost:#{port}", "127.0.0.1:#{port}"],
+          protocol: :meta
+        )
+
+        dc.set('meta_cas_api_key', 'v1')
+        value, cas = dc.get_cas('meta_cas_api_key')
+        assert_equal 'v1', value
+        assert cas.is_a?(Integer)
+        assert cas > 0
+
+        set_cas_result = dc.set_cas('meta_cas_api_key', 'v2', cas)
+        assert set_cas_result.is_a?(Integer)
+        assert set_cas_result > 0
+
+        replace_cas_result = dc.replace_cas('meta_cas_api_key', 'v3', set_cas_result)
+        assert replace_cas_result.is_a?(Integer)
+        assert replace_cas_result > 0
+
+        assert_equal true, dc.delete_cas('meta_cas_api_key', replace_cas_result)
+        assert_nil dc.get('meta_cas_api_key')
+
+        dc.set('meta_multi_cas_1', 'm1')
+        dc.set('meta_multi_cas_2', 'm2')
+        multi = dc.get_multi_cas('meta_multi_cas_1', 'meta_multi_cas_2', 'meta_multi_cas_missing')
+        assert_equal 'm1', multi['meta_multi_cas_1'][0]
+        assert_equal 'm2', multi['meta_multi_cas_2'][0]
+        assert multi['meta_multi_cas_1'][1].is_a?(Integer)
+        assert multi['meta_multi_cas_2'][1].is_a?(Integer)
+        refute multi.key?('meta_multi_cas_missing')
       end
     end
   end


### PR DESCRIPTION
## Summary
- fix meta key decoding to preserve UTF-8 key lookup behavior in `get_multi` while keeping binary key safety
- add meta integration coverage for base64-encoded keys and CAS client APIs, plus a standalone test require fix
- update README protocol documentation for binary/meta support and meta SASL limitation

I have rerun performance benchmarking with these changes (on top of all those which have already been committed and merged to `braze-main`) and updated the spreadsheet. Numbers are essentially unchanged - addition of `:meta` protocol performs within 1% of best performer in all cases - https://docs.google.com/spreadsheets/d/1vvuK2dQya39my5nbosy_gegRxRGLW8xriCdVUC0kkgg/edit?gid=431507583#gid=431507583