### PR TITLE
Fix stale socket data when thread dies mid-request

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -301,30 +301,16 @@ module Dalli
       keys_array
     end
 
-    def make_multi_get_requests(groups)
+    def start_multi_get(groups)
+      servers = []
       groups.each do |server, keys_for_server|
+        next unless server.alive?
         begin
-          # TODO: do this with the perform chokepoint?
-          # But given the fact that fetching the response doesn't take place
-          # in that slot it's misleading anyway. Need to move all of this method
-          # into perform to be meaningful
-          server.request(:send_multiget, keys_for_server)
+          server.multi_response_start(keys_for_server)
+          servers << server
         rescue DalliError, NetworkError => e
           Dalli.logger.debug { e.inspect }
           Dalli.logger.debug { "unable to get keys for server #{server.name}" }
-        end
-      end
-    end
-
-    def perform_multi_response_start(servers)
-      servers.each do |server|
-        next unless server.alive?
-        begin
-          server.multi_response_start
-        rescue DalliError, NetworkError => e
-          Dalli.logger.debug { e.inspect }
-          Dalli.logger.debug { "results from this server will be missing" }
-          servers.delete(server)
         end
       end
       servers
@@ -423,17 +409,15 @@ module Dalli
       perform do
         return {} if keys.empty?
         ring.lock do
-          groups = {}
+          servers = nil
           begin
             groups = groups_for_keys(keys)
             if unfound_keys = groups.delete(nil)
               Dalli.logger.debug { "unable to get keys for #{unfound_keys.length} keys because no matching server was found" }
             end
-            make_multi_get_requests(groups)
 
-            servers = groups.keys
+            servers = start_multi_get(groups)
             return if servers.empty?
-            servers = perform_multi_response_start(servers)
 
             start = Time.now
             while true
@@ -478,6 +462,12 @@ module Dalli
           rescue Timeout::Error
             groups.each_key(&:close)
             raise
+          ensure
+            if servers
+              servers.each do |server|
+                server.multi_response_abort unless server.multi_response_completed?
+              end
+            end
           end
         end
       end

--- a/lib/dalli/options.rb
+++ b/lib/dalli/options.rb
@@ -32,7 +32,7 @@ module Dalli
       end
     end
 
-    def multi_response_start
+    def multi_response_start(keys)
       @lock.synchronize do
         super
       end

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -144,17 +144,23 @@ module Dalli
       @options[:compressor]
     end
 
-    # Start reading key/value pairs from this connection. This is usually called
-    # after a series of GETKQ commands. A NOOP is sent, and the server begins
-    # flushing responses for kv pairs that were found.
+    # Send a batch of GETKQ commands for the given keys, followed by a NOOP
+    # sentinel so the server flushes all responses. Sets @inprogress for the
+    # entire write-read cycle; callers must eventually complete or abort the
+    # multi-response to clear it.
     #
     # Returns nothing.
-    def multi_response_start
+    def multi_response_start(keys)
       verify_state
+      if @pending_multi_response
+        noop
+        @pending_multi_response = false
+      end
+      @inprogress = true
+      send_multiget(keys)
       write_noop
       @multi_buffer = String.new('')
       @position = 0
-      @inprogress = true
     end
 
     # Did the last call to #multi_response_start complete successfully?
@@ -302,7 +308,6 @@ module Dalli
       keys.each do |key|
         req << [REQUEST, OPCODES[:getkq], key.bytesize, 0, 0, 0, key.bytesize, 0, 0, key].pack(FORMAT[:getkq])
       end
-      # Could send noop here instead of in multi_response_start
       write(req)
     end
 

--- a/lib/dalli/server.rb
+++ b/lib/dalli/server.rb
@@ -71,38 +71,39 @@ module Dalli
     def request(op, *args)
       verify_state
       raise Dalli::NetworkError, "#{name} is down: #{@error} #{@msg}. If you are sure it is running, ensure memcached version is > 1.4." unless alive?
+      @inprogress = true
       begin
         # if we have exited a multi block, flush any responses that might still be pending
         if @pending_multi_response && (!multi? || !ALLOWED_MULTI_OPS.include?(op))
           noop
           @pending_multi_response = false
         end
-        send(op, *args)
+        result = send(op, *args)
+        @inprogress = false
+        result
       rescue Dalli::MarshalError => ex
         Dalli.logger.error "Marshalling error for key '#{args.first}': #{ex.message}"
         Dalli.logger.error "You are trying to cache a Ruby object which cannot be serialized to memcached."
         Dalli.logger.error ex.backtrace.join("\n\t")
         false
-      rescue Timeout::Error
-        # A Timeout::Error can be injected asynchronously by Thread#raise
-        # (from Timeout.timeout's watchdog thread) at ANY point in execution.
-        # If it fires between write(req) and reading the response for ANY
-        # operation (GET, SET, DELETE, etc.), the server's response remains
-        # in the socket's receive buffer. Without closing, the next operation
-        # reads those stale bytes as if they were its own response.
-        #
-        # Closing the socket discards any potentially stale data and forces
-        # a fresh connection on the next operation. This may occasionally
-        # close a clean socket (if the timeout fired at a "safe" point), but
-        # the performance cost of an extra reconnect is negligible.
-        close
-        raise
-      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize
+      rescue Dalli::DalliError, Dalli::NetworkError, Dalli::ValueOverMaxSize, Timeout::Error
         raise
       rescue => ex
         Dalli.logger.error "Unexpected exception during Dalli request: #{ex.class.name}: #{ex.message}"
         Dalli.logger.error ex.backtrace.join("\n\t")
         down!
+      ensure
+        # A thread may die (eg via Timeout::Error) at ANY point in execution.
+        # If this occurs between write(req) and reading the response for ANY
+        # operation (GET, SET, DELETE, etc.), the server's response remains
+        # in the socket's receive buffer. Without closing, the next operation
+        # reads those stale bytes as if they were its own response.
+        #
+        # Closing the socket discards any potentially stale data and forces
+        # a fresh connection on the next operation.
+        if @inprogress
+          close
+        end
       end
     end
 
@@ -581,25 +582,15 @@ module Dalli
     end
 
     def write(bytes)
-      begin
-        @inprogress = true
-        result = @sock.write(bytes)
-        @inprogress = false
-        result
-      rescue SystemCallError, Timeout::Error => e
-        failure!(e)
-      end
+      @sock.write(bytes)
+    rescue SystemCallError, Timeout::Error => e
+      failure!(e)
     end
 
     def read(count)
-      begin
-        @inprogress = true
-        data = @sock.readfull(count)
-        @inprogress = false
-        data
-      rescue SystemCallError, Timeout::Error, EOFError => e
-        failure!(e)
-      end
+      @sock.readfull(count)
+    rescue SystemCallError, Timeout::Error, EOFError => e
+      failure!(e)
     end
 
     def read_header

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -112,6 +112,48 @@ describe Dalli::Server do
     end
   end
 
+  describe 'multi_response_start' do
+    it 'sets inprogress and initializes multi_buffer' do
+      memcached_persistent do |dc, port|
+        ring = dc.send(:ring)
+        s = ring.servers.first
+        assert s.alive?
+
+        s.multi_response_start(['somekey'])
+
+        assert_equal true, s.instance_variable_get(:@inprogress)
+        refute_nil s.instance_variable_get(:@multi_buffer)
+        assert_equal 0, s.instance_variable_get(:@position)
+
+        s.multi_response_abort
+      end
+    end
+
+    it 'rejects calls when inprogress is already true' do
+      server.instance_variable_set(:@inprogress, true)
+      assert_raises Dalli::NetworkError do
+        server.multi_response_start(['key'])
+      end
+    end
+
+    it 'flushes pending_multi_response before writing' do
+      memcached_persistent do |dc, port|
+        ring = dc.send(:ring)
+        s = ring.servers.first
+        assert s.alive?
+
+        s.instance_variable_set(:@pending_multi_response, true)
+        s.expects(:noop).once
+
+        s.multi_response_start(['somekey'])
+
+        assert_equal false, s.instance_variable_get(:@pending_multi_response)
+
+        s.multi_response_abort
+      end
+    end
+  end
+
   describe 'multi_response_completed?' do
     it 'returns true when multi_buffer is nil' do
       server.instance_variable_set(:@multi_buffer, nil)
@@ -181,7 +223,7 @@ describe Dalli::Server do
         wrote = Queue.new
 
         s.define_singleton_method(:write) do |bytes|
-          result = super(bytes)
+          super(bytes)
 
           # at this point, the request has been written to the socket, but the response has not been read
           wrote << true
@@ -200,6 +242,42 @@ describe Dalli::Server do
         t.join
 
         assert_nil s.sock, "Socket should have been closed after Thread.kill to prevent stale data"
+      end
+    end
+
+    it 'closes socket when thread is killed during get_multi' do
+      memcached_persistent do |dc|
+        dc.set('a', 'val_a')
+
+        ring = dc.send(:ring)
+        ring.servers.each { |s| assert s.alive? }
+
+        reading = Queue.new
+
+        # Hook multi_response_nonblock on every server. At this point
+        # multi_response_start has already completed: GETKQ + NOOP are
+        # written and @inprogress is true. Hanging here simulates a
+        # Thread.kill arriving while responses are being read.
+        ring.servers.each do |s|
+          s.define_singleton_method(:multi_response_nonblock) do
+            reading << true
+
+            # intentionally hang the thread - it will be killed below
+            Thread.stop
+          end
+        end
+
+        t = Thread.new do
+          dc.get_multi('a')
+        end
+
+        # wait for the response-reading phase, then kill the thread
+        reading.pop
+        t.kill
+        t.join
+
+        involved = ring.servers.find { |s| s.sock.nil? }
+        refute_nil involved, "Socket should have been closed after Thread.kill to prevent stale data"
       end
     end
   end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -171,6 +171,37 @@ describe Dalli::Server do
         end
       end
     end
+
+    it 'closes socket when thread is killed mid-request' do
+      memcached_persistent do |dc|
+        ring = dc.send(:ring)
+        s = ring.servers.first
+        assert s.alive?
+
+        wrote = Queue.new
+
+        s.define_singleton_method(:write) do |bytes|
+          result = super(bytes)
+
+          # at this point, the request has been written to the socket, but the response has not been read
+          wrote << true
+
+          # intentionally hang the thread - it will be killed below
+          Thread.stop
+        end
+
+        t = Thread.new do
+          s.request(:get, 'somekey')
+        end
+
+        # wait for the request to be written to the socket, then kill the thread
+        wrote.pop
+        t.kill
+        t.join
+
+        assert_nil s.sock, "Socket should have been closed after Thread.kill to prevent stale data"
+      end
+    end
   end
 
   describe 'serialize' do


### PR DESCRIPTION
### For single requests (GET, SET, etc)

Move `@inprogress` lifecycle management from individual write/read methods to the request method, covering the entire request-response cycle. Add an `ensure` block that closes the socket if `@inprogress` is still true when the method exits, which handles `Thread.kill` and other unrescuable terminations that bypass rescue blocks but still run ensure.

Previously, `@inprogress` was reset to false after each `write()` call, leaving a gap between write and read where the flag was false. If a thread was killed in this gap, the next thread would pass `verify_state`, send its own request, and read the previous thread's unconsumed response.

Add a test that fails without this change.

### For MGET

Multi-get operations split their write-read cycle across separate methods (`send_multiget` via `request`, then `multi_response_start`, then `multi_response_nonblock`), bypassing `request`'s `ensure` block that closes the socket when `@inprogress` is still true. This left two gaps:

1. Between `request(:send_multiget)` returning (`@inprogress = false`) and
       `multi_response_start` setting `@inprogress = true`, the socket had
       unconsumed response data with no guard. A `Thread.kill` here would
       leave a socket with stale data that the next caller would misread.

2. The response-reading loop in `get_multi_yielder` had no ensure block,
       so `Thread.kill` during multi_response_nonblock left `@inprogress` true
       and the socket open — relying on the next caller to self-heal via
       `verify_state` rather than cleaning up immediately.

Fix by merging send_multiget into `multi_response_start(keys)` so `@inprogress` covers the entire write-read cycle, and adding an ensure block in `get_multi_yielder` that aborts any incomplete multi-responses.