### PR TITLE
[FOUND-193] Lazy/deferred response socket flushing

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -8,6 +8,7 @@ module Dalli
   # Dalli::Client is the main class which developers will use to interact with
   # Memcached.
   ##
+  # rubocop:disable Metrics/ClassLength
   class Client
     ##
     # Dalli::Client is the main class which developers will use to interact with
@@ -47,6 +48,12 @@ module Dalli
     #                 serialization pipeline.
     # - :digest_class - defaults to Digest::MD5, allows you to pass in an object that responds to the hexdigest method,
     #                   useful for injecting a FIPS compliant hash object.
+    # - :defer_drain - defaults to false.  When true, quiet mutations (those run inside a #quiet/#multi block)
+    #                  send their bytes immediately but defer the blocking response drain.  Pending responses are
+    #                  reconciled lazily, with a single amortized noop, before the next operation that needs to read
+    #                  from the connection (or explicitly via #drain_deferred_responses).  This makes scattered single
+    #                  set/delete calls effectively fire-and-forget (no per-op round-trip), at the cost of write
+    #                  errors surfacing on a later operation rather than immediately.
     # - :otel_db_statement - controls the +db.query.text+ span attribute when OpenTelemetry is loaded.
     #                        +:include+ logs the full operation and key(s), +:obfuscate+ replaces keys with "?",
     #                        +nil+ (default) omits the attribute entirely.
@@ -286,10 +293,26 @@ module Dalli
       Thread.current[::Dalli::QUIET] = true
       yield
     ensure
-      @ring&.pipeline_consume_and_ignore_responses
+      # With defer_drain enabled, quiet responses are reconciled lazily before
+      # the next read (or via #drain_deferred_responses) rather than draining with
+      # a blocking noop round-trip on every quiet block exit.  This restores the
+      # fork's fire-and-forget behavior for scattered single mutations.
+      @ring&.pipeline_consume_and_ignore_responses unless @options[:defer_drain]
       Thread.current[::Dalli::QUIET] = old
     end
     alias multi quiet
+
+    ##
+    # Explicitly reconcile any responses left pending by deferred quiet writes
+    # (only relevant when the client is configured with +defer_drain: true+).
+    #
+    # Normal operation drains lazily before the next read, so calling this is
+    # optional.  It is useful at an explicit boundary (e.g. the end of a Rack
+    # request or Sidekiq job) for callers that want write errors surfaced
+    # eagerly rather than on a later operation.
+    def drain_deferred_responses
+      @ring&.drain_deferred_responses
+    end
 
     def set(key, value, ttl = nil, req_options = nil)
       set_cas(key, value, 0, ttl, req_options)
@@ -702,4 +725,5 @@ module Dalli
       PipelinedDeleter.new(ring, @key_manager)
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/dalli/options.rb
+++ b/lib/dalli/options.rb
@@ -31,6 +31,12 @@ module Dalli
       end
     end
 
+    def drain_deferred_responses!
+      @lock.synchronize do
+        super
+      end
+    end
+
     def pipeline_response_setup
       @lock.synchronize do
         super

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -18,7 +18,8 @@ module Dalli
 
       def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size, :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
-                     :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error, :flushed_write
+                     :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error, :flushed_write,
+                     :deferred_responses_pending?
 
       def initialize(attribs, client_options = {})
         hostname, port, socket_type, @weight, user_creds = ServerConfigParser.parse(attribs)
@@ -41,6 +42,7 @@ module Dalli
 
         begin
           @connection_manager.start_request!
+          drain_before_read!(opkey)
           response = send(opkey, *args)
 
           # pipelined_get/pipelined_get_interleaved emit query but don't read the response(s)
@@ -73,6 +75,22 @@ module Dalli
       def lock!; end
 
       def unlock!; end
+
+      # Explicitly drain any responses left pending by deferred quiet writes
+      # (see +defer_drain: true+).  This is a safe no-op when nothing is pending
+      # or the connection is down.  Normal operation reconciles lazily before
+      # the next read, so this is only needed by callers that want write errors
+      # surfaced at an explicit boundary (e.g. the end of a Rack request).
+      def drain_deferred_responses!
+        return unless @connection_manager.deferred_responses_pending?
+        return unless connected?
+
+        @connection_manager.start_request!
+        drain_deferred_responses
+        @connection_manager.finish_request!
+      rescue Dalli::NetworkError
+        nil
+      end
 
       # Start reading key/value pairs from this connection. This is usually called
       # after a series of GETKQ commands. A NOOP is sent, and the server begins
@@ -161,6 +179,29 @@ module Dalli
       # NOTE: Additional public methods should be overridden in Dalli::Threadsafe
 
       private
+
+      # Operations that, when issued in quiet mode, only append a request to the
+      # socket and do not read a response.  We must NOT force a drain before
+      # these, otherwise the deferred-flush optimization would pay a round-trip
+      # per write.  Every other operation reads a response and therefore needs
+      # any prior quiet responses reconciled first.
+      DEFERRABLE_QUIET_OPS = %i[set add replace append prepend delete incr decr flush].freeze
+      private_constant :DEFERRABLE_QUIET_OPS
+
+      def defer_drain?
+        @options[:defer_drain]
+      end
+
+      # Before any operation that reads a response, drain responses left pending
+      # by earlier deferred quiet writes on this connection.  Skipped for the
+      # quiet writes themselves and for noop (which performs its own drain).
+      def drain_before_read!(opkey)
+        return unless @connection_manager.deferred_responses_pending?
+        return if opkey == :noop
+        return if quiet? && DEFERRABLE_QUIET_OPS.include?(opkey)
+
+        drain_deferred_responses
+      end
 
       URI_CREDENTIAL_WARNING = 'Dalli 5.0 removed SASL authentication. ' \
                                'Credentials in memcached:// URIs are ignored.'

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -35,6 +35,7 @@ module Dalli
         @socket_type = socket_type
         @options = DEFAULTS.merge(client_options)
         @request_in_progress = false
+        @pending_quiet = false
         @sock = nil
         @pid = nil
 
@@ -56,6 +57,7 @@ module Dalli
         @sock.sync = false # Enable buffered I/O for better performance
         @pid = PIDCache.pid
         @request_in_progress = false
+        @pending_quiet = false
       rescue SystemCallError, *TIMEOUT_ERRORS, EOFError, SocketError => e
         # SocketError = DNS resolution failure
         error_on_request!(e)
@@ -120,6 +122,7 @@ module Dalli
         end
         @sock = nil
         @pid = nil
+        @pending_quiet = false
         abort_request!
       end
 
@@ -145,6 +148,23 @@ module Dalli
 
       def abort_request!
         @request_in_progress = false
+      end
+
+      # Deferred-drain bookkeeping.  When the client is configured with
+      # +defer_drain: true+, quiet mutations (set/delete/etc.) send their bytes
+      # but skip the blocking response drain.  We record that the connection has
+      # un-drained quiet responses so the next operation that needs to read can
+      # reconcile them with a single noop before proceeding.
+      def deferred_responses_pending?
+        @pending_quiet
+      end
+
+      def mark_responses_deferred!
+        @pending_quiet = true
+      end
+
+      def clear_deferred_responses!
+        @pending_quiet = false
       end
 
       def read_line

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -149,7 +149,7 @@ module Dalli
                                         bitflags: bitflags, cas: cas,
                                         ttl: ttl, mode: mode, quiet: quiet, base64: base64)
         write("#{req}#{value}#{TERMINATOR}")
-        @connection_manager.flush unless quiet
+        finish_write(quiet)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -170,7 +170,7 @@ module Dalli
         req = RequestFormatter.meta_set(key: encoded_key, value: value, base64: base64,
                                         cas: cas, ttl: ttl, mode: mode, quiet: quiet?)
         write("#{req}#{value}#{TERMINATOR}")
-        @connection_manager.flush unless quiet?
+        finish_write(quiet?)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -180,7 +180,7 @@ module Dalli
         req = RequestFormatter.meta_delete(key: encoded_key, cas: cas,
                                            base64: base64, quiet: quiet?)
         write(req)
-        @connection_manager.flush unless quiet?
+        finish_write(quiet?)
         response_processor.meta_delete unless quiet?
       end
 
@@ -206,14 +206,14 @@ module Dalli
         encoded_key, base64 = KeyRegularizer.encode(key)
         write(RequestFormatter.meta_arithmetic(key: encoded_key, delta: delta, initial: initial, incr: incr, ttl: ttl,
                                                quiet: quiet?, base64: base64))
-        @connection_manager.flush unless quiet?
+        finish_write(quiet?)
         response_processor.decr_incr unless quiet?
       end
 
       # Other Commands
       def flush(delay = 0)
         write(RequestFormatter.flush(delay: delay))
-        @connection_manager.flush unless quiet?
+        finish_write(quiet?)
         response_processor.flush unless quiet?
       end
 
@@ -221,7 +221,39 @@ module Dalli
       # We need to read all the responses at once.
       def noop
         write_noop
+        result = response_processor.consume_all_responses_until_mn
+        # A noop drains everything up to and including the MN terminator, so any
+        # deferred quiet responses have now been reconciled.
+        @connection_manager.clear_deferred_responses!
+        result
+      end
+
+      # Completes a write operation.  Non-quiet writes flush so the caller can
+      # immediately read the response.  Quiet writes under +defer_drain: true+
+      # still send their bytes promptly (so the mutation takes effect on the
+      # server right away) but skip the blocking response drain, recording that
+      # the connection has pending quiet responses to reconcile before the next
+      # read.  Legacy quiet behavior (no defer_drain) leaves the bytes buffered
+      # to be drained at the end of the quiet block.
+      def finish_write(quiet)
+        if quiet
+          return unless defer_drain?
+
+          @connection_manager.flush
+          @connection_manager.mark_responses_deferred!
+        else
+          @connection_manager.flush
+        end
+      end
+
+      # Sends a noop barrier and drains all responses (including any error
+      # replies from earlier deferred quiet writes) up to the MN terminator,
+      # then clears the deferred-responses flag.  One amortized round-trip
+      # reconciles any number of preceding deferred writes.
+      def drain_deferred_responses
+        write_noop
         response_processor.consume_all_responses_until_mn
+        @connection_manager.clear_deferred_responses!
       end
 
       def stats(info = nil)

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -124,10 +124,10 @@ module Dalli
         response_processor.meta_set_with_cas unless quiet?
       end
 
-      # Pipelined set - writes a quiet set request without reading response.
+      # Pipelined set - buffers a quiet set request without reading a response.
       # Used by PipelinedSetter for bulk operations.
       def pipelined_set(key, value, ttl, options)
-        write_storage_req(:set, key, value, ttl, nil, options, quiet: true)
+        write_storage_req(:set, key, value, ttl, nil, options, quiet: true, pipelined: true)
       end
 
       def add(key, value, ttl, options)
@@ -141,7 +141,7 @@ module Dalli
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def write_storage_req(mode, key, raw_value, ttl = nil, cas = nil, options = {}, quiet: quiet?)
+      def write_storage_req(mode, key, raw_value, ttl = nil, cas = nil, options = {}, quiet: quiet?, pipelined: false)
         (value, bitflags) = @value_marshaller.store(key, raw_value, options)
         ttl = TtlSanitizer.sanitize(ttl) if ttl
         encoded_key, base64 = KeyRegularizer.encode(key)
@@ -149,7 +149,9 @@ module Dalli
                                         bitflags: bitflags, cas: cas,
                                         ttl: ttl, mode: mode, quiet: quiet, base64: base64)
         write("#{req}#{value}#{TERMINATOR}")
-        finish_write(quiet)
+        # Pipelined writes are flushed and drained by the caller's terminating
+        # noop, so they bypass the (non-)deferred finish_write bookkeeping.
+        finish_write(quiet) unless pipelined
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -227,6 +227,7 @@ module Dalli
         @connection_manager.clear_deferred_responses!
         result
       end
+      alias drain_deferred_responses noop
 
       # Completes a write operation.  Non-quiet writes flush so the caller can
       # immediately read the response.  Quiet writes under +defer_drain: true+
@@ -244,16 +245,6 @@ module Dalli
         else
           @connection_manager.flush
         end
-      end
-
-      # Sends a noop barrier and drains all responses (including any error
-      # replies from earlier deferred quiet writes) up to the MN terminator,
-      # then clears the deferred-responses flag.  One amortized round-trip
-      # reconciles any number of preceding deferred writes.
-      def drain_deferred_responses
-        write_noop
-        response_processor.consume_all_responses_until_mn
-        @connection_manager.clear_deferred_responses!
       end
 
       def stats(info = nil)

--- a/lib/dalli/ring.rb
+++ b/lib/dalli/ring.rb
@@ -90,6 +90,18 @@ module Dalli
       end
     end
 
+    # Explicitly reconcile responses left pending by deferred quiet writes on
+    # each server.  Only servers that actually have pending writes pay a
+    # round-trip; the rest are a no-op.  Used by callers of +defer_drain: true+
+    # that want to force a drain at a boundary.
+    def drain_deferred_responses
+      @servers.each do |s|
+        s.drain_deferred_responses!
+      rescue Dalli::NetworkError
+        # Ignore - the socket is unavailable, so there's nothing to drain
+      end
+    end
+
     def socket_timeout
       @servers.first.socket_timeout
     end

--- a/test/integration/test_defer_drain.rb
+++ b/test/integration/test_defer_drain.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+describe 'defer_drain behavior' do
+  MemcachedManager.supported_protocols.each do |p|
+    describe "using the #{p} protocol" do
+      # Builds a persistent client configured with defer_drain: true.
+      def with_deferred_client(protocol)
+        memcached_persistent(protocol, 21_345, '', { defer_drain: true }) do |dc|
+          dc.close
+          dc.flush
+          yield dc
+        end
+      end
+
+      it 'defers the drain for quiet writes and reconciles before the next read' do
+        with_deferred_client(p) do |dc|
+          key = SecureRandom.hex(3)
+          value = SecureRandom.hex(3)
+
+          dc.quiet do
+            # Quiet writes still return nil
+            assert_nil dc.set(key, value)
+          end
+
+          # The mutation was sent eagerly, so the value is present; the read
+          # transparently reconciles the pending quiet response first.
+          assert_equal value, dc.get(key)
+        end
+      end
+
+      it 'coalesces many quiet mutations across separate quiet blocks' do
+        with_deferred_client(p) do |dc|
+          pairs = Array.new(25) { [SecureRandom.hex(4), SecureRandom.hex(4)] }
+
+          # Each mutation is wrapped in its own quiet block (mirroring the
+          # per-op quiet wrapper used in production). None should block on a
+          # response; the single get below reconciles them all.
+          pairs.each do |k, v|
+            dc.quiet { assert_nil dc.set(k, v) }
+          end
+
+          # Read back in a separate pass to prove the writes were not lost while
+          # their drains were deferred.
+          pairs.each do |k, v| # rubocop:disable Style/CombinableLoops
+            assert_equal v, dc.get(k)
+          end
+        end
+      end
+
+      it 'reconciles pending quiet writes before a non-quiet mutation that reads a response' do
+        with_deferred_client(p) do |dc|
+          quiet_key = SecureRandom.hex(3)
+          quiet_value = SecureRandom.hex(3)
+          direct_key = SecureRandom.hex(3)
+          direct_value = SecureRandom.hex(3)
+
+          dc.quiet { dc.set(quiet_key, quiet_value) }
+
+          # A non-quiet set reads a CAS response; it must drain the pending
+          # quiet response first or the CAS read would be corrupted.
+          assert op_addset_succeeds(dc.set(direct_key, direct_value))
+
+          assert_equal quiet_value, dc.get(quiet_key)
+          assert_equal direct_value, dc.get(direct_key)
+        end
+      end
+
+      it 'does not corrupt the response stream when a quiet write errors' do
+        with_deferred_client(p) do |dc|
+          dc.set('a', 'av')
+          dc.set('b', 'bv')
+
+          dc.quiet do
+            # Deleting a non-existent key produces an error reply that the q
+            # flag does not suppress; it must be drained before later reads.
+            assert_nil dc.delete('non_existent_key')
+          end
+
+          assert_equal 'av', dc.get('a')
+          assert_equal 'bv', dc.get('b')
+        end
+      end
+
+      it 'supports quiet deletes with deferred flushing' do
+        with_deferred_client(p) do |dc|
+          existing = SecureRandom.hex(4)
+          missing = SecureRandom.hex(4)
+          dc.set(existing, 'present')
+
+          dc.quiet do
+            assert_nil dc.delete(existing)
+            assert_nil dc.delete(missing)
+          end
+
+          assert_nil dc.get(existing)
+          assert_nil dc.get(missing)
+        end
+      end
+
+      it 'drains pending responses explicitly via drain_deferred_responses' do
+        with_deferred_client(p) do |dc|
+          key = SecureRandom.hex(3)
+          value = SecureRandom.hex(3)
+
+          dc.quiet { dc.set(key, value) }
+
+          # Force reconciliation at an explicit boundary; subsequent reads then
+          # require no implicit drain but still return the written value.
+          dc.drain_deferred_responses
+
+          assert_equal value, dc.get(key)
+        end
+      end
+
+      it 'clears the pending flag so the next read requires no implicit drain' do
+        with_deferred_client(p) do |dc|
+          key = SecureRandom.hex(3)
+          value = SecureRandom.hex(3)
+
+          dc.quiet { dc.set(key, value) }
+
+          # After a deferred quiet write the server that handled the write has a
+          # pending response flag set; a subsequent read would drain it before
+          # proceeding.  (With multiple servers the write is routed to one of
+          # them, so any? is used rather than a specific index.)
+          servers = dc.send(:ring).servers
+
+          assert servers.any?(&:deferred_responses_pending?),
+                 'expected a pending response after a deferred quiet write'
+
+          # Draining at an explicit boundary (e.g. the end of a Rack request or
+          # Sidekiq job) clears the flag on all servers; the next read will not
+          # need to issue an extra noop round-trip to reconcile the connection.
+          dc.drain_deferred_responses
+
+          refute servers.any?(&:deferred_responses_pending?),
+                 'expected no pending responses after drain_deferred_responses'
+
+          assert_equal value, dc.get(key)
+        end
+      end
+
+      it 'is a no-op to drain_deferred_responses when nothing is pending' do
+        with_deferred_client(p) do |dc|
+          key = SecureRandom.hex(3)
+          value = SecureRandom.hex(3)
+          dc.set(key, value)
+
+          # No deferred responses outstanding -> safe no-op
+          dc.drain_deferred_responses
+
+          assert_equal value, dc.get(key)
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_defer_drain.rb
+++ b/test/integration/test_defer_drain.rb
@@ -14,6 +14,19 @@ describe 'defer_drain behavior' do
         end
       end
 
+      # Wraps each server's noop barrier with a counter so we can assert how many
+      # round-trips a pipelined operation actually performs.
+      def count_noop_barriers(client)
+        counts = Hash.new(0).compare_by_identity
+        client.send(:ring).servers.each do |server|
+          server.define_singleton_method(:write_noop) do
+            counts[self] += 1
+            super()
+          end
+        end
+        counts
+      end
+
       it 'defers the drain for quiet writes and reconciles before the next read' do
         with_deferred_client(p) do |dc|
           key = SecureRandom.hex(3)
@@ -152,6 +165,35 @@ describe 'defer_drain behavior' do
           dc.drain_deferred_responses
 
           assert_equal value, dc.get(key)
+        end
+      end
+
+      it 'pipelines set_multi across servers without a per-key round-trip under defer_drain' do
+        port1 = 23_456
+        port2 = 23_457
+        memcached(p, port1, '', { defer_drain: true }) do
+          memcached(p, port2, '', { defer_drain: true }) do
+            dc = Dalli::Client.new(["127.0.0.1:#{port1}", "127.0.0.1:#{port2}"], defer_drain: true)
+            dc.flush
+
+            pairs = {}
+            40.times { |i| pairs["mk#{i}"] = "mv#{i}" }
+
+            noop_counts = count_noop_barriers(dc)
+            dc.set_multi(pairs)
+
+            total_noops = noop_counts.values.sum
+            server_count = dc.send(:ring).servers.size
+
+            # A correctly pipelined set_multi issues at most one terminating noop
+            # per server.  The regression collapses it into one noop per key
+            # (~40), so anything bounded by the server count proves the fix.
+            assert_operator total_noops, :<=, server_count,
+                            "set_multi issued #{total_noops} noop barriers across " \
+                            "#{server_count} servers; expected pipelined batching"
+
+            pairs.each { |k, v| assert_equal v, dc.get(k) }
+          end
         end
       end
     end


### PR DESCRIPTION
Adds the option to lazily flush responses on the socket, deferring the flush until the next request which requires a response. This copies behavior from the `braze_dalli` fork and should mitigate the performance regression observed for `SET` and `DELETE` operations when upgrading to `dalli v5.0.5` (see discussion https://github.com/Appboy/platform/pull/125632#discussion_r3205543408)

This fork is meant to be temporary – if the changes here result in the intended performance benefit, I will open a PR with `dalli` upstream.

All tests pass locally with `bundle exec rake test` (as of commit [864c9da](https://github.com/mattwd7/dalli/pull/1/commits/864c9da76f2a607b2aa3f28d5dfeb32f5cab8871))